### PR TITLE
add platrorm instruction to POD file

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,3 +1,5 @@
+platform :ios, '10.2'
+
 target 'facebook-live-ios-sample' do
 	pod 'FBSDKShareKit'
 	pod 'FBSDKLoginKit'


### PR DESCRIPTION
For avoiding such message:
[!] Automatically assigning platform `ios` with version `10.2` on target `facebook-live-ios-sample` because no platform was specified. Please specify a platform for this target in your Podfile. See `https://guides.cocoapods.org/syntax/podfile.html#platform`.